### PR TITLE
Convert to post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ _testmain.go
 _examples/client
 _examples/_examples
 _examples/config.json
+config.json
+
 
 # profiling files
 dbpprof

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LINTER ?= golint
 BINDIR := _examples
 BINARY := _examples
 
-VERSION := 0.1.3
+VERSION := 0.1.4
 LDFLAGS = -ldflags "-X main.gitSHA=$(shell git rev-parse HEAD) -X main.version=$(VERSION) -X main.name=$(BINARY)"
 
 OS := $(shell uname)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package no longer supports `HMAC-SHA1`, we recommend use of `HMAC-SHA256`, `
 ### Requirements
 
 ```sh
-git clone https://github.com/emailage/Emailage_Go.git
+git clone https://github.com/emailage/Emailage_Go.git 
 ```
 
 This package can be imported with:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
   <a href="emailage"><img src="https://www.emailage.com/wp-content/uploads/2018/01/logo-dark.svg" width="200" height="200" border="0" alt="Emailage"></a>
 </p>
 <p align="center">
-  <a href="https://github.com/emailage/Emailage_Go/releases"><img src="https://img.shields.io/badge/version-0.1.3-green.svg?" alt="Version"></a>
+  <a href="https://github.com/emailage/Emailage_Go/releases"><img src="https://img.shields.io/badge/version-0.1.4-green.svg?" alt="Version"></a>
   <a href="https://goreportcard.com/report/github.com/emailage/Emailage_Go"><img src="https://goreportcard.com/badge/Emailage/Emailage_Go"></a>
 </p>
 
 The Emailage&#8482; API is organized around REST (Representational State Transfer). The API was built to help companies integrate with our highly efficient fraud risk and scoring system. By calling our API endpoints and simply passing us an email and/or IP Address, companies will be provided with real-time risk scoring assessments based around machine learning and proprietary algorithms that evolve with new fraud trends.
 
-The package only supports `HMAC-SHA1` at this time however it will be extended to include `HMAC-SHA256`, `HMAC-SHA384`, and `HMAC-SHA512`.
+The package no longer supports `HMAC-SHA1`, we recommend use of `HMAC-SHA256`, `HMAC-SHA384`, or `HMAC-SHA512`.
 
 ## Getting Started
 
@@ -67,4 +67,3 @@ if err != nil {
 fmt.Printf("Result: %+v\n", res.Query)
 ```
 
-### Email and IP Validation with extra input parameters

--- a/auth/oauth1.go
+++ b/auth/oauth1.go
@@ -31,7 +31,7 @@ const (
 )
 
 type Authorizer interface {
-	GetSignature(string, RequestMethod, HMACSHA, string) (string, error)
+	GetSignature(string, HMACSHA, string) (string, error)
 	RandomString(length int) string
 }
 
@@ -92,7 +92,7 @@ func (oa *Oauth1) ToBase64(data []byte) string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
-func (oa *Oauth1) GetSignature(fullUrl string, method RequestMethod, hmacsha HMACSHA, token string) (string, error) {
+func (oa *Oauth1) GetSignature(fullUrl string, hmacsha HMACSHA, token string) (string, error) {
 
 	hs, err := oa.HmacEncrypt(fullUrl, token+"&", hmacsha)
 	if err != nil {

--- a/auth/oauth1_test.go
+++ b/auth/oauth1_test.go
@@ -191,7 +191,6 @@ func TestOauth1_GetSignature(t *testing.T) {
 			},
 			args: args{
 				fullUrl: "http://test.com/test/",
-				method:  GET,
 				hmacsha: HMACSHA512,
 				token:   "token",
 			},
@@ -207,7 +206,7 @@ func TestOauth1_GetSignature(t *testing.T) {
 				rnd: random,
 				chs: tt.fields.chs,
 			}
-			got, err := oa.GetSignature(tt.args.fullUrl, tt.args.method, tt.args.hmacsha, tt.args.token)
+			got, err := oa.GetSignature(tt.args.fullUrl, tt.args.hmacsha, tt.args.token)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetSignature() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -237,7 +236,7 @@ func BenchmarkOauth1_HmacEncrypt(b *testing.B) {
 func BenchmarkOauth1_GetSignature(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		oauth, _ := New()
-		oauth.GetSignature("http://test.com/test/", GET, HMACSHA512, "ADSFASDFASDFFASDFASDFFAF")
+		oauth.GetSignature("http://test.com/test/", HMACSHA512, "ADSFASDFASDFFASDFASDFFAF")
 	}
 }
 

--- a/emailage_test.go
+++ b/emailage_test.go
@@ -21,8 +21,8 @@ type authorizer struct {
 	mock.Mock
 }
 
-func (s *authorizer) GetSignature(fullURL string, method auth.RequestMethod, hmacsha auth.HMACSHA, token string) (string, error) {
-	args := s.Called(fullURL, method, hmacsha, token)
+func (s *authorizer) GetSignature(fullURL string, hmacsha auth.HMACSHA, token string) (string, error) {
+	args := s.Called(fullURL, hmacsha, token)
 	return args.String(0), args.Error(1)
 }
 
@@ -294,7 +294,7 @@ func TestErrorCodeLookup(t *testing.T) {
 func TestEmailage_EmailOnlyScore(t *testing.T) {
 	type fields struct {
 		opts *ClientOpts
-		oc   *auth.Authorizer
+		oc   authorizer
 	}
 	type args struct {
 		email  string
@@ -333,7 +333,7 @@ func TestEmailage_EmailOnlyScore(t *testing.T) {
 			},
 			clientMocks: []mockFunc{
 				func() {
-					httpmock.RegisterResponder("GET",
+					httpmock.RegisterResponder("POST",
 						`=~^https://api.exists.somewhere.com/.*`,
 						httpmock.NewStringResponder(200, `{"query":{"email":"nigerian.prince%40legit.ru","queryType":"EmailAgeVerification","count":1,"created":"2019-08-01T00:47:48Z","lang":"en-US","responseCount":1,"results":[{"userdefinedrecordid":"","email":"nigerian.prince@legit.ru","eName":"","emailAge":"","email_creation_days":"","domainAge":"2010-02-08T21:00:00Z","domain_creation_days":"3460","firstVerificationDate":"2018-05-30T17:28:08Z","first_seen_days":"427","lastVerificationDate":"2019-07-31T06:51:02Z","status":"ValidDomain","country":"RU","fraudRisk":"500 Moderate","EAScore":"500","EAReason":"Limited History for Email","EAStatusID":"4","EAReasonID":"8","EAAdviceID":"4","EAAdvice":"Moderate Fraud Risk","EARiskBandID":"3","EARiskBand":"Fraud Score 301 to 600","source_industry":"","fraud_type":"","lastflaggedon":"","dob":"","gender":"","location":"","smfriends":"","totalhits":"14","uniquehits":"1","imageurl":"","emailExists":"Not Sure","domainExists":"Yes","company":"","title":"","domainname":"legit.ru","domaincompany":"","domaincountryname":"Russian Federation","domaincategory":"","domaincorporate":"","domainrisklevel":"Moderate","domainrelevantinfo":"Valid  Domain from Russian Federation","domainrisklevelID":"3","domainrelevantinfoID":"508","domainriskcountry":"No","smlinks":[],"phone_status":"","shipforward":"","overallDigitalIdentityScore":"","emailToIpConfidence":"","emailToPhoneConfidence":"","emailToBillAddressConfidence":"","emailToShipAddressConfidence":"","emailToFullNameConfidence":"","emailToLastNameConfidence":"","ipToPhoneConfidence":"","ipToBillAddressConfidence":"","ipToShipAddressConfidence":"","ipToFullNameConfidence":"","ipToLastNameConfidence":"","phoneToBillAddressConfidence":"","phoneToShipAddressConfidence":"","phoneToFullNameConfidence":"","phoneToLastNameConfidence":"","billAddressToFullNameConfidence":"","billAddressToLastNameConfidence":"","shipAddressToBillAddressConfidence":"","shipAddressToFullNameConfidence":"","shipAddressToLastNameConfidence":""}]},"responseStatus":{"status":"success","errorCode":"0","description":""}}`))
 				},

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,4 @@ module github.com/emailage/Emailage_Go
 go 1.12
 
 require github.com/stretchr/testify v1.3.0
-
 require github.com/jarcoal/httpmock v1.0.4


### PR DESCRIPTION
- Convert requests from GET to POST.
- Update version 0.1.3 -> 0.1.4
- Update documentation to advise against using SHA-1
- NOTE: the GET requests will work if the top-level emailage.go code is updated, but it is recommended that all requests use POST unless there is a specific reason.