### PR TITLE
update: go import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The package no longer supports `HMAC-SHA1`, we recommend use of `HMAC-SHA256`, `
 ### Requirements
 
 ```sh
-git clone https://github.com/emailage/Emailage_Go.git 
+git clone https://github.com/emailage/Emailage_Go.git
 ```
 
 This package can be imported with:
 
 ```Go
-import github.com/emailage/emailage
+go get https://github.com/emailage/Emailage_Go
 ```
 
 ## Usage
@@ -66,4 +66,3 @@ if err != nil {
 }
 fmt.Printf("Result: %+v\n", res.Query)
 ```
-


### PR DESCRIPTION
# What is the goal of this Pull Request
Update README.md file with go import path.

The current import path returns a not found error because the name of the repository is different from the one presented in the file.

# Why this PR is important
As a client of emailage, I couldn't import this repo into my go application. After cloning the repo and thinking hard about why, I noticed the repo name was different from the one presented in the README file. After I used the name from the url, the package downloaded and installed without a problem.  